### PR TITLE
Link back to GitHub repository + documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setup(
     name="ripgrepy",
     version=__version__,
     author=__author__,
+    url='https://github.com/securisec/ripgrepy',
+    project_urls={
+        'Documentation': 'https://ripgrepy.readthedocs.io/',
+        'CI': 'https://travis-ci.com/github/securisec/ripgrepy',
+    },
     packages=find_packages(),
     install_requires = [
     ],


### PR DESCRIPTION
I found this project on https://pypi.org/project/ripgrepy/ but didn't see a link from there back to the GitHub repository. Adding this to `setup.py` will fix this next time the package is shipped to PyPI.