### PR TITLE
Fix logo on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/ripgrepy.svg?logo=python&color=blue)](https://pypi.org/project/ripgrepy/)
 
 
-<img src="https://github.com/securisec/ripgrepy/blob/master/logo.png" width="150px">
+<img src="https://raw.githubusercontent.com/securisec/ripgrepy/master/logo.png" width="150px">
 
 # ripgrepy
 


### PR DESCRIPTION
The logo is broken on https://pypi.org/project/ripgrepy/ at the moment:

<img width="1407" alt="ripgrepy_·_PyPI" src="https://user-images.githubusercontent.com/9599/100164285-6aea0780-2e6c-11eb-9efc-74b3c3ded019.png">
