### PR TITLE
Fix issue #13 of files() and type_list() not working

### DIFF
--- a/ripgrepy/__init__.py
+++ b/ripgrepy/__init__.py
@@ -210,8 +210,10 @@ class Ripgrepy(object):
         :return: self
         :rtype: RipGrepOut
         """
-        self.command.append(self.regex_pattern)
-        self.command.append(self.path)
+        if self.regex_pattern:
+            self.command.append(self.regex_pattern)
+        if self.path:
+            self.command.append(self.path)
         output = subprocess.run(self.command, capture_output=True)
         if output.returncode == 0:
             self._output = output.stdout.decode('UTF-8')
@@ -558,6 +560,7 @@ class Ripgrepy(object):
         :return: self
         :rtype: Ripgrepy
         """
+        self.regex_pattern = ""
         self.command.append("--files")
         return self
 

--- a/ripgrepy/__init__.py
+++ b/ripgrepy/__init__.py
@@ -119,9 +119,9 @@ class Ripgrepy(object):
     :raises RipGrepNotFound: Error if path to ripgrep could not be resolved
     """
 
-    def __init__(self, regex_pattern: str, path: str, rg_path: str = "rg"):
+    def __init__(self, regex_pattern: str = None, path: str = None, rg_path: str = "rg"):
         self.regex_pattern = regex_pattern
-        self.path = os.path.expanduser(path)
+        self.path = path and os.path.expanduser(path)
         self._output = None
         self._rg_path = rg_path
         #: The ripgreg command that will be executed
@@ -210,9 +210,9 @@ class Ripgrepy(object):
         :return: self
         :rtype: RipGrepOut
         """
-        if self.regex_pattern:
+        if self.regex_pattern is not None:
             self.command.append(self.regex_pattern)
-        if self.path:
+        if self.path is not None:
             self.command.append(self.path)
         output = subprocess.run(self.command, capture_output=True)
         if output.returncode == 0:
@@ -560,7 +560,7 @@ class Ripgrepy(object):
         :return: self
         :rtype: Ripgrepy
         """
-        self.regex_pattern = ""
+        self.regex_pattern = None
         self.command.append("--files")
         return self
 
@@ -1391,7 +1391,7 @@ class Ripgrepy(object):
         :return: self
         :rtype: Ripgrepy
         """
-        self.regex_pattern = ""
+        self.regex_pattern = None
         self.command.append("--pcre2-version")
         return self
 
@@ -1561,7 +1561,7 @@ class Ripgrepy(object):
         :return: self
         :rtype: Ripgrepy
         """
-        self.regex_pattern = ""
+        self.regex_pattern = None
         self.command.append('--regexp')
         self.command.append(pattern)
         return self
@@ -1841,8 +1841,8 @@ class Ripgrepy(object):
         :return: self
         :rtype: Ripgrepy
         """
-        self.regex_pattern = ""
-        self.path = ""
+        self.regex_pattern = None
+        self.path = None
         self.command.append("--type-list")
         return self
 


### PR DESCRIPTION
Fix issue #13 and emptying the pattern when using `files()`, and by preventing adding empty the patterns and path to the command. This also fixes the options `type_list()` and `regexp(pattern)`, that were also broken. 

I did it this way because it seems to be what was already expected in the code for type_list() and regexp(pattern).

This PR would prevent creating an object with the arguments to "search for an empty pattern" (i.e. before this change, `Ripgrepy("", ".").run()` valid and equivalent to `rg "" "."`, which is equivalent to `rg --regexp "" "."`.). This basically matches everything, which I guess could be useful (combined with other options) to list the full content of non-ignored searched files in the same format as a pattern-search. But I would doubt that someone currently depends on this "feature" from Ripgrepy... Note thatt it would still be possible to search for this explicitly with `regexp("")`.