### PR TITLE
Fix line splitting from ripgrep --json output

### DIFF
--- a/ripgrepy/__init__.py
+++ b/ripgrepy/__init__.py
@@ -61,9 +61,9 @@ class RipGrepOut(object):
         """
         if "--json" not in self.command:
             raise TypeError("To use as_dict, use the json() method")
-        out = self._output.splitlines()
+        out = self._output.split('\n')
         holder = []
-        for line in out:
+        for line in out[:-1]:
             data = loads(line)
             if data["type"] == "match":
                 holder.append(data)
@@ -81,9 +81,9 @@ class RipGrepOut(object):
         """
         if "--json" not in self.command:
             raise TypeError("To use as_json, use the json() method")
-        out = self._output.splitlines()
+        out = self._output.split('\n')
         holder = []
-        for line in out:
+        for line in out[:-1]:
             data = loads(line)
             if data["type"] == "match":
                 holder.append(data)


### PR DESCRIPTION
`ripgrep --json` results may contain characters that are [considered newlines](https://docs.python.org/3/library/stdtypes.html#str.splitlines) by `str.splitlines`, because it only treats `\n` or `\r\n` as newlines ([this file](https://github.com/ClickHouse/ClickHouse/blob/6567aeda6c63a911a3bf2b3e515782ab9fbc9a60/tests/queries/0_stateless/01666_blns_long.reference) is an example where that happens). `ripgrep`'s output itself is separated by standard newlines.

Tested with dependent [SeaGOAT](https://github.com/kantord/SeaGOAT).