### PR TITLE
Fix deprecated `\w`-style string in docstrings (part 2)

### DIFF
--- a/ripgrepy/__init__.py
+++ b/ripgrepy/__init__.py
@@ -1943,7 +1943,7 @@ class Ripgrepy(object):
 
         ·   Case insensitive matching will use Unicode case folding.
 
-        ·   A large array of classes like \p{Emoji} are available.
+        ·   A large array of classes like \\p{Emoji} are available.
 
         ·   Word boundaries (\\b and \\B) use the Unicode definition of a
             word character.


### PR DESCRIPTION
I missed one in #31, sorry about that